### PR TITLE
add safeguards for request operations

### DIFF
--- a/datasci_ai/errors.py
+++ b/datasci_ai/errors.py
@@ -22,3 +22,11 @@ class IllegalLoadingError(DataSciAIError):
     def __init__(self):
         self.message = "Illegal loading of data! Data should not be loaded through requests."
         super().__init__(self.message)
+
+class IllegalCodeError(DataSciAIError):
+    def __init__(self, name, function=True):
+        if function:
+            self.message = f"Execution of function '{name}' is restricted."
+        else:
+            self.message = f"Access to module '{name}' is restricted."
+        super().__init__(self.message)


### PR DESCRIPTION
The LLM outputs python code, which can be malicious depending on the output of the LLM

safeguards are added to restrict access to modules such as os, and functions such as open(), eval and exec